### PR TITLE
delete: venv path

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,11 +2,6 @@
 python = "3.12"
 uv = "0.10.4"
 
-[env]
-VIRTUAL_ENV = "{{config_root}}/.venv"
-_.path = ["{{config_root}}/.venv/bin"]
-# 必要になったらAPIキーを定義できるよ
-
 [tasks.setup]
 description = "プロジェクトの初期セットアップ"
 run = "uv sync"


### PR DESCRIPTION
close #0

## Summary
タイトル通り

## Changes
- `.mise.toml`のenv部分を削除

## Notes

`uv` に自動で`venv`を選択させたいときは、下記のようにコマンドを打つ必要がある。
```bash
uv run src/main.py  
Hello from meshitouban!
```