### PR TITLE
ci: add configuration file for ci integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,7 @@
 name: python.ci
 
 on:
-  pull_request:
-    paths:
-      - "**/*.py"
-      - ".github/workflows/ci.yml"
   push:
-    branches:
-      - main
     paths:
       - "**/*.py"
       - ".github/workflows/ci.yml"


### PR DESCRIPTION
Close #27 

## Summary
`**.py`を対象としたCIを追加した

## Changes
add `ci.yml`

## Notes
Issue #27 に指定のあった`ubuntu-slim`を使用

この先でbranchを切り、CIのテストを行う予定
https://github.com/25MPOOL/meshiban/pull/51
このDraft PRで確認済み