### PR TITLE
fix: mise tasks command

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -12,20 +12,20 @@ run = "python src/main.py"
 
 [tasks.fmt]
 description = "コードフォーマット"
-run = "ruff format ."
+run = "uv run ruff format ."
 
 [tasks.fmt-check]
 description = "フォーマットチェック（CI用）"
-run = "ruff format . --check"
+run = "uv run ruff format . --check"
 
 [tasks.lint]
 description = "Lintチェック"
-run = "ruff check . --fix"
+run = "uv run ruff check . --fix"
 
 [tasks.lint-check]
 description = "Lintチェック（CI用・自動修正なし）"
-run = "ruff check ."
+run = "uv run ruff check ."
 
 [tasks.test]
 description = "テストの実行"
-run = "pytest"
+run = "uv run pytest"


### PR DESCRIPTION
close #0

## Summary
タイトル通り

## Changes
fmt, lint, testに`uv run `を付けた

## Notes

下記動作テストを行いました。
```bash
meshiban on  chore/mise-tasks-command [$] is 📦 v0.1.0 via 🐍 v3.12.12 
❯ mise run fmt
[fmt] $ uv run ruff format .
1 file left unchanged

meshiban on  chore/mise-tasks-command [$] is 📦 v0.1.0 via 🐍 v3.12.12 
❯ mise run lint 
[lint] $ uv run ruff check . --fix
All checks passed!

meshiban on  chore/mise-tasks-command [$] is 📦 v0.1.0 via 🐍 v3.12.12 
❯ mise run test
[test] $ uv run pytest
====================================================================================== test session starts =======================================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/miyakoshi/kaihatsu/meshiban
configfile: pyproject.toml
collected 0 items                                                                                                                                                                                

===================================================================================== no tests ran in 0.00s ======================================================================================
[test] ERROR task failed
```