### PR TITLE
chore: renovate のpythonアップデートPRを出さないようにする

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,4 +3,10 @@
     "github>suzuki-shunsuke/renovate-config#3.3.1",
     "github>aquaproj/aqua-renovate-config:file#2.10.0(aqua/.*\\.ya?ml)",
   ],
+  packageRules: [
+    {
+      matchPackageNames: ["python"],
+      enabled: false,
+    },
+  ],
 }


### PR DESCRIPTION
close #0

## Summary
タイトル通り

## Changes
プッシュするたびにPR来るの嫌なので

## Notes

