### PR TITLE
ci: pinactの検証をPR作成時に行う

### DIFF
--- a/.github/workflows/check-action-pins.yaml
+++ b/.github/workflows/check-action-pins.yaml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 


### PR DESCRIPTION
close #43 

## Summary
タイトル通り

## Changes
タグ指定になってれば、CIが落ちるようになってる。

## Notes

