### PR TITLE
Fix(mise): run dev command

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -8,7 +8,7 @@ run = "uv sync"
 
 [tasks.dev]
 description = "Discord Botの起動"
-run = "uv run python src/main.py"
+run = "uv run src/main.py"
 
 [tasks.fmt]
 description = "コードフォーマット"


### PR DESCRIPTION
close #0

## Summary
タイトル通り

## Changes
`dev`コマンドの`python`が必要なかったので削除した

## Notes
botは以前同様正しくログインできます

```
meshiban=fix-mise-run-dev-command on  fix/mise-run-dev-command is 📦 v0.1.0 via 🐍 v3.12.12 took 32s 
❯ mise run dev
[dev] $ uv run src/main.py
2026-03-07 21:19:27 INFO     discord.client logging in using static token
2026-03-07 21:19:29 INFO     discord.gateway Shard ID None has connected to Gateway (Session ID: ????).
We have logged in as meshiban-stg#6069
```